### PR TITLE
feat: Add multi-line input support with IME handling for chat interface

### DIFF
--- a/src/app/components/ChatInterface/ChatInterface.module.scss
+++ b/src/app/components/ChatInterface/ChatInterface.module.scss
@@ -169,21 +169,33 @@
   border-top: 1px solid var(--color-border);
   background-color: var(--color-background);
   flex-shrink: 0;
+  align-items: flex-end;
 }
 
 .input {
   flex: 1;
-  padding-left: 10px;
+  padding: 10px;
+  min-height: 40px;
+  max-height: 200px;
+  line-height: 1.5;
+  overflow-y: auto;
+  
+  &::-webkit-scrollbar {
+    width: 0;
+    display: none;
+  }
 }
 
 .sendButton {
   padding: $spacing-sm $spacing-md;
+  margin-bottom: 2px;
 }
 
 .stopButton {
   padding: $spacing-sm $spacing-md;
   background-color: var(--color-error);
   color: white;
+  margin-bottom: 2px;
 
   &:hover {
     opacity: 0.9;

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex min-h-[60px] w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none resize-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };


### PR DESCRIPTION
## Description
This PR enhances the chat input field to support multi-line text input with proper IME (Input Method Editor) handling for languages like Japanese, Chinese, and Korean.

## Changes
- ✨ Replace single-line `Input` component with multi-line `Textarea` component
- ⌨️ Add keyboard shortcuts:
  - `Enter`: Send message
  - `Shift+Enter`: Insert new line
- 📐 Implement auto-resize functionality (max height: 200px)
- 🌏 Fix IME composition issue where pressing Enter during character conversion would submit the form
- 🎨 Remove scrollbar for cleaner UI appearance

## Motivation
The previous single-line input was limiting for users who wanted to compose longer messages or format their text with line breaks. Additionally, users typing in languages that use IME (Japanese, Chinese, Korean) experienced issues where pressing Enter to confirm character conversion would inadvertently submit the message.

## Testing
- [x] Tested multi-line input with Shift+Enter
- [x] Tested message submission with Enter
- [x] Tested auto-resize functionality
- [x] Tested Japanese input without premature submission
- [x] Tested on macOS with Chrome/Safari/Firefox

## Screenshots
<img width="1954" height="1024" alt="CleanShot 2025-08-19 at 18 25 59@2x" src="https://github.com/user-attachments/assets/eb6cd9bd-7a8f-4a21-8979-820927f69224" />
