### PR TITLE
Bump langchain version to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "deep-agents-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@langchain/core": "^0.3.68",
-        "@langchain/langgraph-sdk": "^0.0.105",
+        "@langchain/core": "^1.0.1",
+        "@langchain/langgraph-sdk": "^1.0.0",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-scroll-area": "^1.2.9",
         "@radix-ui/react-slot": "^1.2.3",
@@ -836,9 +836,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "0.3.68",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.68.tgz",
-      "integrity": "sha512-dWPT1h9ObG1TK9uivFTk/pgBULZ6/tBmq8czGUjZjR+1xh9jB4tm/D5FY6o5FklXcEpnAI9peNq2x17Kl9wbMg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-hVM3EkojYOk4ISJQKjLuWYSH6kyyOFlZIrLFETDA1L0Z2/Iu0q32aJawZ0FDn6rlXE8QZjBt/9OaOL36rXc05w==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -846,16 +846,15 @@
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.46",
+        "langsmith": "^0.3.64",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
         "p-retry": "4",
         "uuid": "^10.0.0",
-        "zod": "^3.25.32",
-        "zod-to-json-schema": "^3.22.3"
+        "zod": "^3.25.76 || ^4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@langchain/core/node_modules/ansi-styles": {
@@ -884,18 +883,17 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "0.0.105",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.105.tgz",
-      "integrity": "sha512-3DD1W1wnbP48807qq+5gY248mFcwwNGqKdmZt05P3zeLpfP5Sfm6ELzVvqHGpr+qumP0yGRZs/7qArYGXRRfcQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.0.0.tgz",
+      "integrity": "sha512-g25ti2W7Dl5wUPlNK+0uIGbeNFqf98imhHlbdVVKTTkDYLhi/pI1KTgsSSkzkeLuBIfvt2b0q6anQwCs7XBlbw==",
       "license": "MIT",
       "dependencies": {
-        "@types/json-schema": "^7.0.15",
         "p-queue": "^6.6.2",
         "p-retry": "4",
         "uuid": "^9.0.0"
       },
       "peerDependencies": {
-        "@langchain/core": ">=0.2.31 <0.4.0",
+        "@langchain/core": "^1.0.1",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19"
       },
@@ -2409,6 +2407,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -3681,12 +3680,12 @@
       "license": "MIT"
     },
     "node_modules/console-table-printer": {
-      "version": "2.14.6",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
-      "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
+      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
       "license": "MIT",
       "dependencies": {
-        "simple-wcswidth": "^1.0.1"
+        "simple-wcswidth": "^1.1.2"
       }
     },
     "node_modules/cross-spawn": {
@@ -5823,9 +5822,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.3.55",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.55.tgz",
-      "integrity": "sha512-YC/e6lUIYSkheOq9PR6O4CV6GOhYHyPvF2w0SOk85Mw4P5ae/oFdjuFsv7BCjKhPs4vFWC6Fz/qxPTz9mXNhVw==",
+      "version": "0.3.74",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.74.tgz",
+      "integrity": "sha512-ZuW3Qawz8w88XcuCRH91yTp6lsdGuwzRqZ5J0Hf5q/AjMz7DwcSv0MkE6V5W+8hFMI850QZN2Wlxwm3R9lHlZg==",
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^10.0.0",
@@ -9487,21 +9486,12 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@langchain/core": "^0.3.68",
-    "@langchain/langgraph-sdk": "^0.0.105",
+    "@langchain/core": "^1.0.1",
+    "@langchain/langgraph-sdk": "^1.0.0",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-slot": "^1.2.3",


### PR DESCRIPTION
Hi,
We see the following errors before bumping version:
```
Received: { "content": "", "additional_kwargs": {}, "response_metadata": {}, "type": "remove", "name": null, "id": "__remove_all__" }
```

After bumping things work as expected.