### PR TITLE
fix: add key prop to mapped divs in ChatInterface component

### DIFF
--- a/src/app/components/ChatInterface.tsx
+++ b/src/app/components/ChatInterface.tsx
@@ -634,7 +634,7 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(
                         Object.entries(groupedTodos)
                           .filter(([_, todos]) => todos.length > 0)
                           .map(([status, todos]) => (
-                            <div className="mb-4">
+                            <div key={status} className="mb-4">
                               <h3 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-tertiary">
                                 {
                                   {


### PR DESCRIPTION
## Fix: Add missing key prop to todo status groups in ChatInterface

### Problem
React was throwing a console.error about missing `key` prop for list children in the ChatInterface component:

<img width="1424" height="879" alt="Captura de pantalla 2025-11-30 a la(s) 11 00 59 a  m" src="https://github.com/user-attachments/assets/6dbd614e-12ad-422e-83e1-ae6cdf465c97" />

This happens when you click on this task detail in Chat Input
<img width="1174" height="206" alt="Captura de pantalla 2025-11-30 a la(s) 11 01 22 a  m" src="https://github.com/user-attachments/assets/66a0a986-de31-4f61-8812-dcd40cb98adb" />

### Solution
Added `key={status}` prop to the div element 