### PR TITLE
Use fetchStateHistory

### DIFF
--- a/src/app/hooks/useChat.ts
+++ b/src/app/hooks/useChat.ts
@@ -44,6 +44,7 @@ export function useChat({
     threadId: threadId ?? null,
     onThreadId: setThreadId,
     defaultHeaders: { "x-auth-scheme": "langsmith" },
+    fetchStateHistory: true,
     // Revalidate thread list when stream finishes, errors, or creates new thread
     onFinish: onHistoryRevalidate,
     onError: onHistoryRevalidate,


### PR DESCRIPTION
After updating the UI to the latest versio I experienced an UI crash complaining about the fetchStateHistory not being enabled. This patch fixes it.

Closes: https://github.com/langchain-ai/deep-agents-ui/issues/42