### PR TITLE
fix: enable fetch history when switching to existing threads

### DIFF
--- a/src/app/hooks/useChat.ts
+++ b/src/app/hooks/useChat.ts
@@ -44,6 +44,8 @@ export function useChat({
     threadId: threadId ?? null,
     onThreadId: setThreadId,
     defaultHeaders: { "x-auth-scheme": "langsmith" },
+    // Enable fetching state history when switching to existing threads
+    fetchStateHistory: true,
     // Revalidate thread list when stream finishes, errors, or creates new thread
     onFinish: onHistoryRevalidate,
     onError: onHistoryRevalidate,


### PR DESCRIPTION
When switching between existing threads you would get an error:

``fetchStateHistory` must be set to `true` to use `history``

This small fix enables fetching state history when switching to existing threads! 

Validated by testing locally. 