### PR TITLE
Fix mixed message content parsing and prevent truncated AI responses

### DIFF
--- a/src/app/hooks/useThreads.ts
+++ b/src/app/hooks/useThreads.ts
@@ -2,6 +2,7 @@ import useSWRInfinite from "swr/infinite";
 import type { Thread } from "@langchain/langgraph-sdk";
 import { Client } from "@langchain/langgraph-sdk";
 import { getConfig } from "@/lib/config";
+import { extractStringFromMessageContent } from "@/app/utils/utils";
 
 export interface ThreadItem {
   id: string;
@@ -96,20 +97,18 @@ export function useThreads(props: {
               (m: any) => m.type === "human"
             );
             if (firstHumanMessage?.content) {
-              const content =
-                typeof firstHumanMessage.content === "string"
-                  ? firstHumanMessage.content
-                  : firstHumanMessage.content[0]?.text || "";
+              const content = extractStringFromMessageContent(
+                firstHumanMessage as any
+              );
               title = content.slice(0, 50) + (content.length > 50 ? "..." : "");
             }
             const firstAiMessage = values.messages.find(
               (m: any) => m.type === "ai"
             );
             if (firstAiMessage?.content) {
-              const content =
-                typeof firstAiMessage.content === "string"
-                  ? firstAiMessage.content
-                  : firstAiMessage.content[0]?.text || "";
+              const content = extractStringFromMessageContent(
+                firstAiMessage as any
+              );
               description = content.slice(0, 100);
             }
           }


### PR DESCRIPTION
## Overview

This PR fixes issues where AI messages and thread previews were rendered incompletely when message content was streamed or chunked. Mixed content (text objects + raw strings) caused broken sentences, missing chunks, and truncated thread titles.

## Root Cause

The existing logic assumed message content was either a single string or an array whose first item was a { type: "text" } object. In reality, content can be a mixed array, causing later chunks to be ignored.

## Changes Made

### 1) Robust content extraction

- Replaced fragile filter().map() logic with a safe for...of loop.

- Added explicit handling for both string chunks and { type: "text", text } objects.

- Concatenated content seamlessly to avoid broken sentences.

### 2) Fixed LLM message formatting

- Updated formatMessageForLLM to use the same safe parsing logic.

- Removed artificial paragraph breaks from streamed chunks.

### 3) Fixed truncated thread titles/descriptions

- Updated thread summaries to use the new content extraction utility.

- Removed reliance on content[0].

## Result

1. AI messages render fully and correctly.

2. No broken formatting or missing content.

3. Thread titles and descriptions reflect the complete message.

## Scope & Safety

- No breaking changes

- No API changes

- Fix is limited to message parsing and thread summaries


Fixes #53 