### PR TITLE
fix: resolve React Fast Refresh ESLint warnings

### DIFF
--- a/src/app/components/ChatInterface.tsx
+++ b/src/app/components/ChatInterface.tsx
@@ -26,7 +26,7 @@ import type {
 } from "@/app/types/types";
 import { Assistant, Message } from "@langchain/langgraph-sdk";
 import { extractStringFromMessageContent } from "@/app/utils/utils";
-import { useChatContext } from "@/providers/ChatProvider";
+import { useChatContext } from "@/providers/ChatContext";
 import { cn } from "@/lib/utils";
 import { useStickToBottom } from "use-stick-to-bottom";
 import { FilesPopover } from "@/app/components/TasksFilesSidebar";

--- a/src/app/components/TasksFilesSidebar.tsx
+++ b/src/app/components/TasksFilesSidebar.tsx
@@ -16,7 +16,7 @@ import {
 } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { TodoItem, FileItem } from "@/app/types/types";
-import { useChatContext } from "@/providers/ChatProvider";
+import { useChatContext } from "@/providers/ChatContext";
 import { cn } from "@/lib/utils";
 import { FileViewDialog } from "@/app/components/FileViewDialog";
 

--- a/src/app/hooks/useChat.ts
+++ b/src/app/hooks/useChat.ts
@@ -10,7 +10,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import type { UseStreamThread } from "@langchain/langgraph-sdk/react";
 import type { TodoItem } from "@/app/types/types";
-import { useClient } from "@/providers/ClientProvider";
+import { useClient } from "@/providers/ClientContext";
 import { useQueryState } from "nuqs";
 
 export type StateType = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,8 @@ import { getConfig, saveConfig, StandaloneConfig } from "@/lib/config";
 import { ConfigDialog } from "@/app/components/ConfigDialog";
 import { Button } from "@/components/ui/button";
 import { Assistant } from "@langchain/langgraph-sdk";
-import { ClientProvider, useClient } from "@/providers/ClientProvider";
+import { ClientProvider } from "@/providers/ClientProvider";
+import { useClient } from "@/providers/ClientContext";
 import { Settings, MessagesSquare, SquarePen } from "lucide-react";
 import {
   ResizableHandle,

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -1,0 +1,32 @@
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,39 +1,9 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import { type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-);
+import { buttonVariants } from "./button-variants";
 
 function Button({
   className,
@@ -56,4 +26,4 @@ function Button({
   );
 }
 
-export { Button, buttonVariants };
+export { Button };

--- a/src/providers/ChatContext.ts
+++ b/src/providers/ChatContext.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { useChat } from "@/app/hooks/useChat";
+
+export type ChatContextType = ReturnType<typeof useChat>;
+
+export const ChatContext = createContext<ChatContextType | undefined>(
+  undefined
+);
+
+export function useChatContext() {
+  const context = useContext(ChatContext);
+  if (context === undefined) {
+    throw new Error("useChatContext must be used within a ChatProvider");
+  }
+  return context;
+}

--- a/src/providers/ChatProvider.tsx
+++ b/src/providers/ChatProvider.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { ReactNode, createContext, useContext } from "react";
+import { ReactNode } from "react";
 import { Assistant } from "@langchain/langgraph-sdk";
 import { type StateType, useChat } from "@/app/hooks/useChat";
 import type { UseStreamThread } from "@langchain/langgraph-sdk/react";
+import { ChatContext } from "./ChatContext";
 
 interface ChatProviderProps {
   children: ReactNode;
@@ -22,16 +23,3 @@ export function ChatProvider({
   return <ChatContext.Provider value={chat}>{children}</ChatContext.Provider>;
 }
 
-export type ChatContextType = ReturnType<typeof useChat>;
-
-export const ChatContext = createContext<ChatContextType | undefined>(
-  undefined
-);
-
-export function useChatContext() {
-  const context = useContext(ChatContext);
-  if (context === undefined) {
-    throw new Error("useChatContext must be used within a ChatProvider");
-  }
-  return context;
-}

--- a/src/providers/ClientContext.ts
+++ b/src/providers/ClientContext.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import { Client } from "@langchain/langgraph-sdk";
+
+interface ClientContextValue {
+  client: Client;
+}
+
+export const ClientContext = createContext<ClientContextValue | null>(null);
+
+export function useClient(): Client {
+  const context = useContext(ClientContext);
+
+  if (!context) {
+    throw new Error("useClient must be used within a ClientProvider");
+  }
+  return context.client;
+}

--- a/src/providers/ClientProvider.tsx
+++ b/src/providers/ClientProvider.tsx
@@ -1,13 +1,8 @@
 "use client";
 
-import { createContext, useContext, useMemo, ReactNode } from "react";
+import { useMemo, ReactNode } from "react";
 import { Client } from "@langchain/langgraph-sdk";
-
-interface ClientContextValue {
-  client: Client;
-}
-
-const ClientContext = createContext<ClientContextValue | null>(null);
+import { ClientContext } from "./ClientContext";
 
 interface ClientProviderProps {
   children: ReactNode;
@@ -35,13 +30,4 @@ export function ClientProvider({
   return (
     <ClientContext.Provider value={value}>{children}</ClientContext.Provider>
   );
-}
-
-export function useClient(): Client {
-  const context = useContext(ClientContext);
-
-  if (!context) {
-    throw new Error("useClient must be used within a ClientProvider");
-  }
-  return context.client;
 }


### PR DESCRIPTION
## Summary

Separates hooks and contexts from component files to improve React Fast Refresh reliability and resolve ESLint warnings.

**Changes:**
- Extract `buttonVariants` to `button-variants.ts`
- Extract `ChatContext` and `useChatContext` to `ChatContext.ts`  
- Extract `ClientContext` and `useClient` to `ClientContext.ts`
- Update imports in consuming files

## Before

```
$ yarn lint

/src/components/ui/button.tsx
  59:18  warning  Fast refresh only works when a file only exports components...

/src/providers/ChatProvider.tsx
  27:14  warning  Fast refresh only works when a file only exports components...
  31:17  warning  Fast refresh only works when a file only exports components...

/src/providers/ClientProvider.tsx
  40:17  warning  Fast refresh only works when a file only exports components...

✖ 4 problems (0 errors, 4 warnings)
```

## After

```
$ yarn lint
Done in 1.08s.
```

## Test plan

- [x] `yarn lint` passes with no warnings
- [x] `yarn build` succeeds
- [x] Manual testing of the UI

Made with [Cursor](https://cursor.com)