### PR TITLE
Support env var defaults for deployment URL and assistant ID

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,13 +10,26 @@ export function getConfig(): StandaloneConfig | null {
   if (typeof window === "undefined") return null;
 
   const stored = localStorage.getItem(CONFIG_KEY);
-  if (!stored) return null;
-
-  try {
-    return JSON.parse(stored);
-  } catch {
-    return null;
+  if (stored) {
+    try {
+      return JSON.parse(stored);
+    } catch {
+      // fall through to env defaults
+    }
   }
+
+  // Fall back to env vars so new users get sensible defaults
+  const deploymentUrl = process.env.NEXT_PUBLIC_DEPLOYMENT_URL;
+  const assistantId = process.env.NEXT_PUBLIC_ASSISTANT_ID;
+  if (deploymentUrl && assistantId) {
+    return {
+      deploymentUrl,
+      assistantId,
+      langsmithApiKey: process.env.NEXT_PUBLIC_LANGSMITH_API_KEY,
+    };
+  }
+
+  return null;
 }
 
 export function saveConfig(config: StandaloneConfig): void {


### PR DESCRIPTION
`getConfig()` in `src/lib/config.ts` now falls back to `NEXT_PUBLIC_DEPLOYMENT_URL` and `NEXT_PUBLIC_ASSISTANT_ID` environment variables when localStorage has no saved config. This lets operators pre-configure the connection via `.env.local` so new users skip the settings dialog.

`NEXT_PUBLIC_LANGSMITH_API_KEY` is also picked up (consistent with existing README docs).

Example `.env.local`:

```env
NEXT_PUBLIC_DEPLOYMENT_URL=http://127.0.0.1:2024
NEXT_PUBLIC_ASSISTANT_ID=research
```

Closes #40