### PR TITLE
Fix code block rendering for react-markdown v9

### DIFF
--- a/src/app/components/MarkdownContent.tsx
+++ b/src/app/components/MarkdownContent.tsx
@@ -59,6 +59,13 @@ export const MarkdownContent = React.memo<MarkdownContentProps>(
                 >
                   {String(children).replace(/\n$/, "")}
                 </SyntaxHighlighter>
+              ) : !inline ? (
+                <code
+                  className="bg-surface block whitespace-pre-wrap rounded-md p-4 font-mono text-[0.875rem]"
+                  {...props}
+                >
+                  {String(children).replace(/\n$/, "")}
+                </code>
               ) : (
                 <code
                   className="bg-surface rounded-sm px-1 py-0.5 font-mono text-[0.9em]"

--- a/src/app/components/MarkdownContent.tsx
+++ b/src/app/components/MarkdownContent.tsx
@@ -6,7 +6,7 @@ import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { cn } from "@/lib/utils";
-import type { Element, ElementContent, Text } from "hast";
+import type { Element, ElementContent } from "hast";
 
 interface MarkdownContentProps {
   content: string;
@@ -80,9 +80,9 @@ export const MarkdownContent = React.memo<MarkdownContentProps>(
                       {getCodeText(codeNode).replace(/\n$/, "")}
                     </SyntaxHighlighter>
                   ) : (
-                    <div className="bg-surface block whitespace-pre-wrap rounded-md p-4 font-mono text-[0.875rem]">
-                      {children}
-                    </div>
+                    <code className="bg-surface block whitespace-pre-wrap rounded-md p-4 font-mono text-[0.875rem]">
+                      {getCodeText(codeNode).replace(/\n$/, "")}
+                    </code>
                   )}
                 </div>
               );
@@ -147,7 +147,7 @@ export const MarkdownContent = React.memo<MarkdownContentProps>(
 /** Extract text content from a hast element node */
 function getCodeText(node: ElementContent | Element | undefined): string {
   if (!node) return "";
-  if (node.type === "text") return (node as Text).value || "";
+  if ("value" in node) return node.value || "";
   if ("children" in node) {
     return (node.children as ElementContent[])
       .map((child) => getCodeText(child))

--- a/src/app/components/MarkdownContent.tsx
+++ b/src/app/components/MarkdownContent.tsx
@@ -24,49 +24,10 @@ export const MarkdownContent = React.memo<MarkdownContentProps>(
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           components={{
-            code({
-              inline,
-              className,
-              children,
-              ...props
-            }: {
-              inline?: boolean;
-              className?: string;
-              children?: React.ReactNode;
-            }) {
-              const match = /language-(\w+)/.exec(className || "");
-              return !inline && match ? (
-                <SyntaxHighlighter
-                  style={oneDark}
-                  language={match[1]}
-                  PreTag="div"
-                  className="max-w-full rounded-md text-sm"
-                  wrapLines={true}
-                  wrapLongLines={true}
-                  lineProps={{
-                    style: {
-                      wordBreak: "break-all",
-                      whiteSpace: "pre-wrap",
-                      overflowWrap: "break-word",
-                    },
-                  }}
-                  customStyle={{
-                    margin: 0,
-                    maxWidth: "100%",
-                    overflowX: "auto",
-                    fontSize: "0.875rem",
-                  }}
-                >
-                  {String(children).replace(/\n$/, "")}
-                </SyntaxHighlighter>
-              ) : !inline ? (
-                <code
-                  className="bg-surface block whitespace-pre-wrap rounded-md p-4 font-mono text-[0.875rem]"
-                  {...props}
-                >
-                  {String(children).replace(/\n$/, "")}
-                </code>
-              ) : (
+            // In react-markdown v9, fenced code blocks render as <pre><code>...</code></pre>.
+            // We handle block code in the `pre` component and keep `code` for inline only.
+            code({ children, ...props }) {
+              return (
                 <code
                   className="bg-surface rounded-sm px-1 py-0.5 font-mono text-[0.9em]"
                   {...props}
@@ -75,10 +36,46 @@ export const MarkdownContent = React.memo<MarkdownContentProps>(
                 </code>
               );
             },
-            pre({ children }: { children?: React.ReactNode }) {
+            pre({ children, node }: { children?: React.ReactNode; node?: any }) {
+              // Extract language and text from the <code> child element
+              const codeNode = node?.children?.find(
+                (child: any) => child.tagName === "code"
+              );
+              const className = codeNode?.properties?.className?.[0] || "";
+              const match = /language-(\w+)/.exec(className);
+              const text = getCodeText(codeNode);
+
               return (
                 <div className="my-4 max-w-full overflow-hidden last:mb-0">
-                  {children}
+                  {match ? (
+                    <SyntaxHighlighter
+                      style={oneDark}
+                      language={match[1]}
+                      PreTag="div"
+                      className="max-w-full rounded-md text-sm"
+                      wrapLines={true}
+                      wrapLongLines={true}
+                      lineProps={{
+                        style: {
+                          wordBreak: "break-all",
+                          whiteSpace: "pre-wrap",
+                          overflowWrap: "break-word",
+                        },
+                      }}
+                      customStyle={{
+                        margin: 0,
+                        maxWidth: "100%",
+                        overflowX: "auto",
+                        fontSize: "0.875rem",
+                      }}
+                    >
+                      {text.replace(/\n$/, "")}
+                    </SyntaxHighlighter>
+                  ) : (
+                    <code className="bg-surface block whitespace-pre-wrap rounded-md p-4 font-mono text-[0.875rem]">
+                      {text.replace(/\n$/, "")}
+                    </code>
+                  )}
                 </div>
               );
             },
@@ -138,5 +135,15 @@ export const MarkdownContent = React.memo<MarkdownContentProps>(
     );
   }
 );
+
+/** Extract text content from a hast code node */
+function getCodeText(node: any): string {
+  if (!node) return "";
+  if (node.type === "text") return node.value || "";
+  if (node.children) {
+    return node.children.map((child: any) => getCodeText(child)).join("");
+  }
+  return "";
+}
 
 MarkdownContent.displayName = "MarkdownContent";

--- a/src/app/components/MarkdownContent.tsx
+++ b/src/app/components/MarkdownContent.tsx
@@ -80,9 +80,9 @@ export const MarkdownContent = React.memo<MarkdownContentProps>(
                       {getCodeText(codeNode).replace(/\n$/, "")}
                     </SyntaxHighlighter>
                   ) : (
-                    <code className="bg-surface block whitespace-pre-wrap rounded-md p-4 font-mono text-[0.875rem]">
-                      {getCodeText(codeNode).replace(/\n$/, "")}
-                    </code>
+                    <div className="bg-surface whitespace-pre-wrap rounded-md p-4 font-mono text-[0.875rem] [&_code]:bg-transparent [&_code]:p-0 [&_code]:rounded-none [&_code]:text-inherit">
+                      {children}
+                    </div>
                   )}
                 </div>
               );

--- a/src/app/components/MarkdownContent.tsx
+++ b/src/app/components/MarkdownContent.tsx
@@ -6,6 +6,7 @@ import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { cn } from "@/lib/utils";
+import type { Element, ElementContent, Text } from "hast";
 
 interface MarkdownContentProps {
   content: string;
@@ -36,14 +37,21 @@ export const MarkdownContent = React.memo<MarkdownContentProps>(
                 </code>
               );
             },
-            pre({ children, node }: { children?: React.ReactNode; node?: any }) {
-              // Extract language and text from the <code> child element
+            pre({ children, node }: { children?: React.ReactNode; node?: Element }) {
+              // Extract language from the <code> child's hast node
               const codeNode = node?.children?.find(
-                (child: any) => child.tagName === "code"
+                (child): child is Element =>
+                  child.type === "element" && child.tagName === "code"
               );
-              const className = codeNode?.properties?.className?.[0] || "";
-              const match = /language-(\w+)/.exec(className);
-              const text = getCodeText(codeNode);
+              const classNames = codeNode?.properties?.className;
+              const langClass =
+                Array.isArray(classNames)
+                  ? classNames.find(
+                      (cls): cls is string =>
+                        typeof cls === "string" && /^language-/.test(cls)
+                    )
+                  : undefined;
+              const match = langClass ? /language-(\w+)/.exec(langClass) : null;
 
               return (
                 <div className="my-4 max-w-full overflow-hidden last:mb-0">
@@ -69,12 +77,12 @@ export const MarkdownContent = React.memo<MarkdownContentProps>(
                         fontSize: "0.875rem",
                       }}
                     >
-                      {text.replace(/\n$/, "")}
+                      {getCodeText(codeNode).replace(/\n$/, "")}
                     </SyntaxHighlighter>
                   ) : (
-                    <code className="bg-surface block whitespace-pre-wrap rounded-md p-4 font-mono text-[0.875rem]">
-                      {text.replace(/\n$/, "")}
-                    </code>
+                    <div className="bg-surface block whitespace-pre-wrap rounded-md p-4 font-mono text-[0.875rem]">
+                      {children}
+                    </div>
                   )}
                 </div>
               );
@@ -136,12 +144,14 @@ export const MarkdownContent = React.memo<MarkdownContentProps>(
   }
 );
 
-/** Extract text content from a hast code node */
-function getCodeText(node: any): string {
+/** Extract text content from a hast element node */
+function getCodeText(node: ElementContent | Element | undefined): string {
   if (!node) return "";
-  if (node.type === "text") return node.value || "";
-  if (node.children) {
-    return node.children.map((child: any) => getCodeText(child)).join("");
+  if (node.type === "text") return (node as Text).value || "";
+  if ("children" in node) {
+    return (node.children as ElementContent[])
+      .map((child) => getCodeText(child))
+      .join("");
   }
   return "";
 }


### PR DESCRIPTION
## Summary

Fixes two related code block rendering issues in `MarkdownContent.tsx`:

1. **Fenced code blocks without a language** (bare ``` fences) collapsed all whitespace into a single line because the handler only rendered block-level output when a language class was matched.

2. **Inline code rendered as block elements** — in react-markdown v9, the `inline` prop is never passed to the `code` component (always `undefined`), so `!inline` was always `true`. This caused all code elements (including inline code in tables) to hit the block code path with full padding and `display: block`.

## Changes

- Move block code handling from the `code` component into `pre`, matching react-markdown v9's architecture where fenced blocks render as `<pre><code>...</code></pre>`
- `code` component now only handles inline code
- `pre` component extracts language from the hast `code` child node: renders `SyntaxHighlighter` when a language is present, or `{children}` (preserving React children / plugin transformations) for no-language blocks
- Use CSS descendant selectors (`[&_code]:bg-transparent [&_code]:p-0 ...`) on the no-language wrapper to reset inner `code` styles, avoiding double background/padding
- Add proper hast types (`Element`, `ElementContent`) instead of `any`
- Search the full `className` array for the `language-` prefix instead of taking index `[0]`