### PR TITLE
ci: add minimum workflow permissions and SHA-pin third-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #
@@ -75,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: codespell-project/actions-codespell@v2
+      - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
         with:
           ignore_words_file: .codespellignore
           path: README.md
@@ -85,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: codespell-project/actions-codespell@v2
+      - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
         with:
           ignore_words_file: .codespellignore
           path: src

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -4,7 +4,7 @@ permissions:
   pull-requests: read
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR Title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

- `ci.yml`: add `permissions: contents: read` top-level block (Rule 1)
- `ci.yml`: SHA-pin `codespell-project/actions-codespell@v2` → `@406322ec...` (Rule 6)
- `pr_lint.yml`: SHA-pin `amannn/action-semantic-pull-request@v6` → `@48f25628...` (Rule 6)
- `pr_lint.yml`: change trigger `pull_request` → `pull_request_target` to prevent token exfiltration via unpinned/malicious action (Rule 7)

## Test plan

- [x] CI workflow still runs on push/PR and passes format, lint, build, spelling checks
- [x] PR lint workflow triggers on `pull_request_target` and validates PR titles as before
- [x] No workflow permission regression (all scopes remain read-only)
